### PR TITLE
Cloud-Init/bash script installer for Ubuntu 20.04

### DIFF
--- a/contrib/ubuntu_installer.sh
+++ b/contrib/ubuntu_installer.sh
@@ -1,16 +1,18 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
-## Note: before running this, you may wish to edit the default variables at the
-## top of this script. You may also set variables in your environment to
-## override the default values.
+## Note: before running this, you may wish to edit the lightspeed_config
+## function below (review all of the variables that start with the `DEFAULT_`
+## prefix). You may also set variables in your shell environment to override the
+## default values (same names, but without the `DEFAULT_` prefix).
 
 ## This is a bash script to install GRVYDEV/Project-Lightspeed on Ubuntu 20.04,
-## from source code. In addition, the Caddy webserver will be installed (which
-## can optionally provide TLS certificate from Lets Encrypt, and secure-proxy
-## the websocket). This script should be run as root, or invoked from
-## cloud-init. (On DigitalOcean, create a droplet and copy-paste this *entire
-## file* into the droplet `User Data` text area, and edit the DEFAULT variables
-## below. The droplet will run this script automatically when it is created.)
+## from source code. In addition, the nginx webserver and certbot will be
+## installed (Lets Encrypt TLS certificate will automatically be created if you
+## set TLS_ON=true and set DOMAIN). This script should be run as root, or
+## invoked from cloud-init. (On DigitalOcean, create a droplet and copy-paste
+## this *entire file* into the droplet `User Data` text area, and edit the
+## DEFAULT variables below. The droplet will run this script automatically when
+## it is created.)
 
 ## If you are you using cloud-init, you can watch the output of this script, run:
 ##   tail -f /var/log/cloud-init-output.log
@@ -19,35 +21,47 @@
 ## (this should eventually say `status: done` and not `status: error`)
 
 ## Once the ingest service has started, you can view the logs to find your stream key:
-##   journalctl --unit lightspeed-ingest.service
+##   journalctl --unit lightspeed-ingest.service --no-pager
 
-#### Default variables you may wish to edit:
-# TLS is off by default. Turn on HTTPS and proxy the websocket by setting DEFAULT_TLS_ON=true
-## NOTE: TLS is BROKEN at the moment, keep this as `false` at least for now:
-DEFAULT_TLS_ON=false
+## If you set DEFAULT_TLS_ON=true (or TLS_ON=true from the environment), nginx
+## will be configured for TLS, and automatically redirect http traffic to https.
+## The websocket will be proxied as a secure websocket (wss:// instead of ws://)
+## This requires a proper DNS entry for your DOMAIN. If you know your IP address
+## ahead of time, create the DNS entry first, before running this script. If you
+## are running this on DigitalOcean via cloud-init, you won't know the IP
+## address until after you create the droplet, so you must act quickly:
+## immediately after you create the droplet, find the IP address, and create the
+## DNS entry for the chosen DEFAULT_DOMAIN. certbot runs at the very end of this
+## script, so it will not need this for several minutes, so you have a bit of
+## time to set the DNS entry before it needs it.
 
-# Domain name for your stream website (setting only required if DEFAULT_TLS_ON=true):
-DEFAULT_DOMAIN=stream.example.com
+## EDIT THIS CONFIG HERE:
+lightspeed_config() {
+    # TLS is off by default.
+    # Turn on HTTPS and proxy the websocket by setting DEFAULT_TLS_ON=true
+    ## NOTE: TLS is BROKEN at the moment, keep this as `false` at least for now:
+    DEFAULT_TLS_ON=false
+    # YOUR email address to register Lets Encrypt account (only when TLS_ON=true)
+    DEFAULT_ACME_EMAIL=email@example.com
 
-# Automatically get the public IP address of DigitalOcean droplet via metadata URL:
-# (You might need a different command if you're not using DigitalOcean)
-# Alternatively, you can set IP_ADDRESS=x.x.x.x if you know it already:
-DEFAULT_IP_ADDRESS=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+    # Domain name for your stream website (only when TLS_ON=true):
+    DEFAULT_DOMAIN=stream.example.com
 
-# Generate a new random stream key:
-DEFAULT_STREAM_KEY=$RANDOM-$(openssl rand -hex 16)
+    # Automatically get the public IP address of DigitalOcean droplet via metadata URL:
+    # (You might need a different command if you're not using DigitalOcean)
+    # Alternatively, you can set DEFAULT_IP_ADDRESS=x.x.x.x if you know it already:
+    DEFAULT_IP_ADDRESS=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
 
-# Git repositories:
-## NOTE: Using ingest fork that includes random stream key generation:
-DEFAULT_INGEST_REPO=https://github.com/obviyus/Lightspeed-ingest.git
-DEFAULT_WEBRTC_REPO=https://github.com/GRVYDEV/Lightspeed-webrtc.git
-DEFAULT_REACT_REPO=https://github.com/GRVYDEV/Lightspeed-react.git
+    # Git repositories:
+    DEFAULT_INGEST_REPO=https://github.com/GRVYDEV/Lightspeed-ingest.git
+    DEFAULT_WEBRTC_REPO=https://github.com/GRVYDEV/Lightspeed-webrtc.git
+    DEFAULT_REACT_REPO=https://github.com/GRVYDEV/Lightspeed-react.git
 
-# Git branch, tag, or commit to compile (default is HEAD from mainline branch):
-## NOTE: Using streamkey branch that includes random stream key generation:
-DEFAULT_INGEST_GIT_REF=streamkey
-DEFAULT_WEBRTC_GIT_REF=main
-DEFAULT_REACT_GIT_REF=master
+    # Git branch, tag, or commit to compile (default is HEAD from mainline branch):
+    DEFAULT_INGEST_GIT_REF=master
+    DEFAULT_WEBRTC_GIT_REF=main
+    DEFAULT_REACT_GIT_REF=master
+}
 
 
 ## END CONFIG
@@ -61,107 +75,95 @@ DEFAULT_REACT_GIT_REF=master
 ##
 ##
 
-## Load environment variables that possibly override default values:
-# (env vars are the same names as above, except without `DEFAULT_` prefix)
-TLS_ON=${TLS_ON:-$DEFAULT_TLS_ON}
-DOMAIN=${DOMAIN:-$DEFAULT_DOMAIN}
-IP_ADDRESS=${IP_ADDRESS:-$DEFAULT_IP_ADDRESS}
-INGEST_REPO=${INGEST_REPO:-$DEFAULT_INGEST_REPO}
-WEBRTC_REPO=${WEBRTC_REPO:-$DEFAULT_WEBRTC_REPO}
-REACT_REPO=${REACT_REPO:-$DEFAULT_REACT_REPO}
-INGEST_GIT_REF=${INGEST_GIT_REF:-$DEFAULT_INGEST_GIT_REF}
-WEBRTC_GIT_REF=${WEBRTC_GIT_REF:-$DEFAULT_WEBRTC_GIT_REF}
-REACT_GIT_REF=${REACT_GIT_REF:-$DEFAULT_REACT_GIT_REF}
+lightspeed_install() {
+    ## Load environment variables that possibly override default values:
+    # (env vars are the same names as above, except without `DEFAULT_` prefix)
+    TLS_ON=${TLS_ON:-$DEFAULT_TLS_ON}
+    DOMAIN=${DOMAIN:-$DEFAULT_DOMAIN}
+    IP_ADDRESS=${IP_ADDRESS:-$DEFAULT_IP_ADDRESS}
+    INGEST_REPO=${INGEST_REPO:-$DEFAULT_INGEST_REPO}
+    WEBRTC_REPO=${WEBRTC_REPO:-$DEFAULT_WEBRTC_REPO}
+    REACT_REPO=${REACT_REPO:-$DEFAULT_REACT_REPO}
+    INGEST_GIT_REF=${INGEST_GIT_REF:-$DEFAULT_INGEST_GIT_REF}
+    WEBRTC_GIT_REF=${WEBRTC_GIT_REF:-$DEFAULT_WEBRTC_GIT_REF}
+    REACT_GIT_REF=${REACT_GIT_REF:-$DEFAULT_REACT_GIT_REF}
+    ACME_EMAIL=${ACME_EMAIL:-$DEFAULT_ACME_EMAIL}
 
-if [ ${TLS_ON} = 'true' ]; then
-    CADDY_DOMAIN=${DOMAIN}
-    WEBRTC_IP_ADDRESS=127.0.0.1
-    WEBSOCKET_URL=wss://${DOMAIN}/api/websocket
-else
-    CADDY_DOMAIN=":80"
-    WEBRTC_IP_ADDRESS=${IP_ADDRESS}
-    WEBSOCKET_URL=ws://${IP_ADDRESS}:8080/websocket
-fi
+    if [ ${TLS_ON} = 'true' ]; then
+        WEBRTC_IP_ADDRESS=127.0.0.1
+        WEBSOCKET_URL=wss://${DOMAIN}/websocket
+    else
+        WEBRTC_IP_ADDRESS=${IP_ADDRESS}
+        WEBSOCKET_URL=ws://${IP_ADDRESS}:8080/websocket
+    fi
 
-export HOME=/root
-export DEBIAN_FRONTEND=noninteractive
-apt-get update
-apt-get -y install \
-        golang \
-        nodejs \
-        npm \
-        git \
-        debian-keyring \
-        debian-archive-keyring \
-        apt-transport-https \
-        curl
+    export HOME=/root
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get -y install \
+            golang \
+            nodejs \
+            npm \
+            git \
+            debian-keyring \
+            debian-archive-keyring \
+            apt-transport-https \
+            curl \
+            nginx \
+            certbot \
+            python3-certbot-nginx
 
-## Latest rust version:
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source /root/.cargo/env
+    ## Latest rust version:
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source /root/.cargo/env
 
-## Niceties:
-echo "set enable-bracketed-paste on" >> /root/.inputrc
+    ## Niceties:
+    echo "set enable-bracketed-paste on" >> /root/.inputrc
 
-## Caddy:
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/gpg/gpg.155B6D79CA56EA34.key' | sudo apt-key add -
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/setup/config.deb.txt?distro=debian&version=any-version' | sudo tee -a /etc/apt/sources.list.d/caddy-stable.list
-apt-get update
-apt-get install -y caddy
-cat <<EOF > /etc/caddy/Caddyfile
-${CADDY_DOMAIN} {
-  root * /var/www/html
-  file_server
-  handle_path /api/* {
-    uri strip_prefix /api
-    reverse_proxy 127.0.0.1:8080
-  }
-}
-EOF
-systemctl restart caddy
 
-## Install Project Lightspeed from source:
-# ingest:
-mkdir -p /root/git
-cd /root/git
-git clone ${INGEST_REPO} Lightspeed-ingest
-cd Lightspeed-ingest
-git checkout ${INGEST_GIT_REF}
-cargo build --release
-install target/release/lightspeed-ingest /usr/local/bin/lightspeed-ingest
+    ## Install Project Lightspeed from source:
+    # ingest:
+    mkdir -p /root/git
+    cd /root/git
+    git clone ${INGEST_REPO} Lightspeed-ingest
+    cd Lightspeed-ingest
+    git checkout ${INGEST_GIT_REF}
+    cargo build --release
+    install target/release/lightspeed-ingest /usr/local/bin/lightspeed-ingest
 
-# webrtc:
-cd /root/git
-git clone ${WEBRTC_REPO} Lightspeed-webrtc
-cd Lightspeed-webrtc
-git checkout ${WEBRTC_GIT_REF}
-GO111MODULE=on go build
-install lightspeed-webrtc /usr/local/bin/lightspeed-webrtc
+    # webrtc:
+    cd /root/git
+    git clone ${WEBRTC_REPO} Lightspeed-webrtc
+    cd Lightspeed-webrtc
+    git checkout ${WEBRTC_GIT_REF}
+    GO111MODULE=on go build
+    install lightspeed-webrtc /usr/local/bin/lightspeed-webrtc
 
-# react:
-cd /root/git
-git clone ${REACT_REPO} Lightspeed-react
-cd Lightspeed-react
-git checkout ${REACT_GIT_REF}
-npm install
-npm run build
-mkdir -p /var/www/html
-cp -a build/* /var/www/html
-cat <<EOF > /var/www/html/config.json
+    # react:
+    cd /root/git
+    git clone ${REACT_REPO} Lightspeed-react
+    cd Lightspeed-react
+    git checkout ${REACT_GIT_REF}
+    npm install
+    npm run build
+    mkdir -p /var/www/html
+    cp -a build/* /var/www/html
+    cat <<EOF > /var/www/html/config.json
 {
   "wsUrl": "${WEBSOCKET_URL}"
 }
 EOF
 
-## Create systemd service for ingest:
+    ## Create systemd service for ingest:
 
-cat <<'EOF' > /etc/systemd/system/lightspeed-ingest.service
+    cat <<EOF > /etc/systemd/system/lightspeed-ingest.service
 [Unit]
 Description=Project Lightspeed ingest service
 After=network-online.target
 
 [Service]
 TimeoutStartSec=0
+Environment=LS_INGEST_ADDR=${IP_ADDRESS}
 ExecStart=/usr/local/bin/lightspeed-ingest
 Restart=always
 RestartSec=60
@@ -170,9 +172,9 @@ RestartSec=60
 WantedBy=network-online.target
 EOF
 
-## Create systemd service for webrtc:
+    ## Create systemd service for webrtc:
 
-cat <<EOF | sed 's/@@@/$/g' > /etc/systemd/system/lightspeed-webrtc.service
+    cat <<EOF | sed 's/@@@/$/g' > /etc/systemd/system/lightspeed-webrtc.service
 [Unit]
 Description=Project Lightspeed webrtc service
 After=network-online.target
@@ -188,9 +190,57 @@ RestartSec=60
 WantedBy=network-online.target
 EOF
 
-## Install and start services:
+    ## Install and start services:
 
-systemctl daemon-reload
-systemctl enable --now lightspeed-ingest
-systemctl enable --now lightspeed-webrtc
+    systemctl daemon-reload
+    systemctl enable --now lightspeed-ingest
+    systemctl enable --now lightspeed-webrtc
 
+    ## Configure TLS with certbot:
+
+    if [ ${TLS_ON} = 'true' ]; then
+        certbot -n register --agree-tos -m ${ACME_EMAIL}
+        certbot -n --nginx --domains ${DOMAIN}
+        cat <<EOF | sed 's/@@@/$/g' > /etc/nginx/sites-available/default
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 301 https://@@@host@@@request_uri;
+}
+
+server {
+    server_name ${DOMAIN};
+    listen 443 ssl;
+    listen [::]:443 ssl ipv6only=on;
+    root /var/www/html;
+    index index.html;
+    location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to displaying a 404.
+        try_files @@@uri @@@uri/ =404;
+    }
+    location /websocket {
+        proxy_pass http://127.0.0.1:8080/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade @@@http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host @@@host;
+    }
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+EOF
+
+        systemctl restart nginx
+    fi
+}
+
+## Configure and install:
+lightspeed_config
+lightspeed_install
+
+
+## END

--- a/contrib/ubuntu_installer.sh
+++ b/contrib/ubuntu_installer.sh
@@ -97,12 +97,12 @@ lightspeed_install() {
     fi
 
     export HOME=/root
+
+    ## Install packages:
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get -y install \
             golang \
-            nodejs \
-            npm \
             git \
             debian-keyring \
             debian-archive-keyring \
@@ -112,13 +112,16 @@ lightspeed_install() {
             certbot \
             python3-certbot-nginx
 
-    ## Latest rust version:
+    ## Install latest nodejs and npm:
+    curl -sL https://deb.nodesource.com/setup_15.x | bash -
+    apt-get install -y nodejs
+
+    ## Install latest rust version:
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     source /root/.cargo/env
 
     ## Niceties:
     echo "set enable-bracketed-paste on" >> /root/.inputrc
-
 
     ## Install Project Lightspeed from source:
     # ingest:

--- a/contrib/ubuntu_installer.sh
+++ b/contrib/ubuntu_installer.sh
@@ -39,7 +39,6 @@
 lightspeed_config() {
     # TLS is off by default.
     # Turn on HTTPS and proxy the websocket by setting DEFAULT_TLS_ON=true
-    ## NOTE: TLS is BROKEN at the moment, keep this as `false` at least for now:
     DEFAULT_TLS_ON=false
     # YOUR email address to register Lets Encrypt account (only when TLS_ON=true)
     DEFAULT_ACME_EMAIL=email@example.com

--- a/contrib/ubuntu_installer.sh
+++ b/contrib/ubuntu_installer.sh
@@ -1,0 +1,196 @@
+#!/bin/bash -e
+
+## Note: before running this, you may wish to edit the default variables at the
+## top of this script. You may also set variables in your environment to
+## override the default values.
+
+## This is a bash script to install GRVYDEV/Project-Lightspeed on Ubuntu 20.04,
+## from source code. In addition, the Caddy webserver will be installed (which
+## can optionally provide TLS certificate from Lets Encrypt, and secure-proxy
+## the websocket). This script should be run as root, or invoked from
+## cloud-init. (On DigitalOcean, create a droplet and copy-paste this *entire
+## file* into the droplet `User Data` text area, and edit the DEFAULT variables
+## below. The droplet will run this script automatically when it is created.)
+
+## If you are you using cloud-init, you can watch the output of this script, run:
+##   tail -f /var/log/cloud-init-output.log
+## Or you can wait for it to finish by running:
+##   cloud-init status -w
+## (this should eventually say `status: done` and not `status: error`)
+
+## Once the ingest service has started, you can view the logs to find your stream key:
+##   journalctl --unit lightspeed-ingest.service
+
+#### Default variables you may wish to edit:
+# TLS is off by default. Turn on HTTPS and proxy the websocket by setting DEFAULT_TLS_ON=true
+## NOTE: TLS is BROKEN at the moment, keep this as `false` at least for now:
+DEFAULT_TLS_ON=false
+
+# Domain name for your stream website (setting only required if DEFAULT_TLS_ON=true):
+DEFAULT_DOMAIN=stream.example.com
+
+# Automatically get the public IP address of DigitalOcean droplet via metadata URL:
+# (You might need a different command if you're not using DigitalOcean)
+# Alternatively, you can set IP_ADDRESS=x.x.x.x if you know it already:
+DEFAULT_IP_ADDRESS=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+
+# Generate a new random stream key:
+DEFAULT_STREAM_KEY=$RANDOM-$(openssl rand -hex 16)
+
+# Git repositories:
+## NOTE: Using ingest fork that includes random stream key generation:
+DEFAULT_INGEST_REPO=https://github.com/obviyus/Lightspeed-ingest.git
+DEFAULT_WEBRTC_REPO=https://github.com/GRVYDEV/Lightspeed-webrtc.git
+DEFAULT_REACT_REPO=https://github.com/GRVYDEV/Lightspeed-react.git
+
+# Git branch, tag, or commit to compile (default is HEAD from mainline branch):
+## NOTE: Using streamkey branch that includes random stream key generation:
+DEFAULT_INGEST_GIT_REF=streamkey
+DEFAULT_WEBRTC_GIT_REF=main
+DEFAULT_REACT_GIT_REF=master
+
+
+## END CONFIG
+## You shouldn't need to edit anything below this line.
+##
+##
+##
+##
+##
+##
+##
+##
+
+## Load environment variables that possibly override default values:
+# (env vars are the same names as above, except without `DEFAULT_` prefix)
+TLS_ON=${TLS_ON:-$DEFAULT_TLS_ON}
+DOMAIN=${DOMAIN:-$DEFAULT_DOMAIN}
+IP_ADDRESS=${IP_ADDRESS:-$DEFAULT_IP_ADDRESS}
+INGEST_REPO=${INGEST_REPO:-$DEFAULT_INGEST_REPO}
+WEBRTC_REPO=${WEBRTC_REPO:-$DEFAULT_WEBRTC_REPO}
+REACT_REPO=${REACT_REPO:-$DEFAULT_REACT_REPO}
+INGEST_GIT_REF=${INGEST_GIT_REF:-$DEFAULT_INGEST_GIT_REF}
+WEBRTC_GIT_REF=${WEBRTC_GIT_REF:-$DEFAULT_WEBRTC_GIT_REF}
+REACT_GIT_REF=${REACT_GIT_REF:-$DEFAULT_REACT_GIT_REF}
+
+if [ ${TLS_ON} = 'true' ]; then
+    CADDY_DOMAIN=${DOMAIN}
+    WEBRTC_IP_ADDRESS=127.0.0.1
+    WEBSOCKET_URL=wss://${DOMAIN}/api/websocket
+else
+    CADDY_DOMAIN=":80"
+    WEBRTC_IP_ADDRESS=${IP_ADDRESS}
+    WEBSOCKET_URL=ws://${IP_ADDRESS}:8080/websocket
+fi
+
+export HOME=/root
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get -y install \
+        golang \
+        nodejs \
+        npm \
+        git \
+        debian-keyring \
+        debian-archive-keyring \
+        apt-transport-https \
+        curl
+
+## Latest rust version:
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source /root/.cargo/env
+
+## Niceties:
+echo "set enable-bracketed-paste on" >> /root/.inputrc
+
+## Caddy:
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/gpg/gpg.155B6D79CA56EA34.key' | sudo apt-key add -
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/setup/config.deb.txt?distro=debian&version=any-version' | sudo tee -a /etc/apt/sources.list.d/caddy-stable.list
+apt-get update
+apt-get install -y caddy
+cat <<EOF > /etc/caddy/Caddyfile
+${CADDY_DOMAIN} {
+  root * /var/www/html
+  file_server
+  handle_path /api/* {
+    uri strip_prefix /api
+    reverse_proxy 127.0.0.1:8080
+  }
+}
+EOF
+systemctl restart caddy
+
+## Install Project Lightspeed from source:
+# ingest:
+mkdir -p /root/git
+cd /root/git
+git clone ${INGEST_REPO} Lightspeed-ingest
+cd Lightspeed-ingest
+git checkout ${INGEST_GIT_REF}
+cargo build --release
+install target/release/lightspeed-ingest /usr/local/bin/lightspeed-ingest
+
+# webrtc:
+cd /root/git
+git clone ${WEBRTC_REPO} Lightspeed-webrtc
+cd Lightspeed-webrtc
+git checkout ${WEBRTC_GIT_REF}
+GO111MODULE=on go build
+install lightspeed-webrtc /usr/local/bin/lightspeed-webrtc
+
+# react:
+cd /root/git
+git clone ${REACT_REPO} Lightspeed-react
+cd Lightspeed-react
+git checkout ${REACT_GIT_REF}
+npm install
+npm run build
+mkdir -p /var/www/html
+cp -a build/* /var/www/html
+cat <<EOF > /var/www/html/config.json
+{
+  "wsUrl": "${WEBSOCKET_URL}"
+}
+EOF
+
+## Create systemd service for ingest:
+
+cat <<'EOF' > /etc/systemd/system/lightspeed-ingest.service
+[Unit]
+Description=Project Lightspeed ingest service
+After=network-online.target
+
+[Service]
+TimeoutStartSec=0
+ExecStart=/usr/local/bin/lightspeed-ingest
+Restart=always
+RestartSec=60
+
+[Install]
+WantedBy=network-online.target
+EOF
+
+## Create systemd service for webrtc:
+
+cat <<EOF | sed 's/@@@/$/g' > /etc/systemd/system/lightspeed-webrtc.service
+[Unit]
+Description=Project Lightspeed webrtc service
+After=network-online.target
+
+[Service]
+TimeoutStartSec=0
+Environment=IP_ADDRESS=${WEBRTC_IP_ADDRESS}
+ExecStart=/usr/local/bin/lightspeed-webrtc --addr=@@@{IP_ADDRESS}
+Restart=always
+RestartSec=60
+
+[Install]
+WantedBy=network-online.target
+EOF
+
+## Install and start services:
+
+systemctl daemon-reload
+systemctl enable --now lightspeed-ingest
+systemctl enable --now lightspeed-webrtc
+

--- a/contrib/ubuntu_installer.sh
+++ b/contrib/ubuntu_installer.sh
@@ -90,7 +90,7 @@ lightspeed_install() {
     ACME_EMAIL=${ACME_EMAIL:-$DEFAULT_ACME_EMAIL}
 
     if [ ${TLS_ON} = 'true' ]; then
-        WEBRTC_IP_ADDRESS=127.0.0.1
+        WEBRTC_IP_ADDRESS=${IP_ADDRESS}
         WEBSOCKET_URL=wss://${DOMAIN}/websocket
     else
         WEBRTC_IP_ADDRESS=${IP_ADDRESS}
@@ -221,7 +221,7 @@ server {
         try_files @@@uri @@@uri/ =404;
     }
     location /websocket {
-        proxy_pass http://127.0.0.1:8080/websocket;
+        proxy_pass http://${IP_ADDRESS}:8080/websocket;
         proxy_http_version 1.1;
         proxy_set_header Upgrade @@@http_upgrade;
         proxy_set_header Connection "Upgrade";

--- a/contrib/ubuntu_installer.sh
+++ b/contrib/ubuntu_installer.sh
@@ -227,7 +227,12 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade @@@http_upgrade;
         proxy_set_header Connection "Upgrade";
+        proxy_set_header X-Real-IP @@@remote_addr;
+        proxy_set_header X-Forwarded-For @@@proxy_add_x_forwarded_for;
         proxy_set_header Host @@@host;
+        proxy_connect_timeout   24h;
+        proxy_send_timeout      24h;
+        proxy_read_timeout      24h;
     }
     ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;


### PR DESCRIPTION
Hi, this project is so awesome, fantastic :1st_place_medal: 

This is an installer script to install all the components from source code, and that works tested on a $5 DigitalOcean droplet (Ubuntu 20.04). You just have to paste the entire script into the droplet creation screen, under the section called `User data` (its a checkbox that opens a text-area. Paste the entire script into the text-area) The `User data` is cloud-init, it will run the install script when the droplet starts. See the top of the script for more details.

The git repositories to clone are configurable, as well as the branch or commit to checkout. This makes it easy to test from a fork or PR branch. ~~Right now I have it set to use the PR from https://github.com/GRVYDEV/Lightspeed-ingest/pull/24 so that is generates a random stream key by default.~~ Now that PR has been merged we're back on master.

~~This also installs Caddy, which serves the react static HTML.~~ Now this install nginx and certbot. certbot creates TLS (HTTPs) certificates and nginx proxys the websocket (wss:// to ws://). 