### PR TITLE
Corrected which branch the ingest is pulled from in installer script

### DIFF
--- a/contrib/ubuntu_installer/ubuntu_installer.sh
+++ b/contrib/ubuntu_installer/ubuntu_installer.sh
@@ -28,7 +28,7 @@ lightspeed_config() {
     DEFAULT_REACT_REPO=https://github.com/GRVYDEV/Lightspeed-react.git
 
     # Git branch, tag, or commit to compile (default is HEAD from mainline branch):
-    DEFAULT_INGEST_GIT_REF=master
+    DEFAULT_INGEST_GIT_REF=main
     DEFAULT_WEBRTC_GIT_REF=main
     DEFAULT_REACT_GIT_REF=master
 


### PR DESCRIPTION
The default is main rather than master. There was a patch to fix systemd problems with logging https://github.com/GRVYDEV/Lightspeed-ingest/pull/34 that was only merged into main which this script needs to run without failing the systemd setup.

Ignore if this is intentional and `main` will be merged into `master` at a later time.