### PR TITLE
[Bugfix] gcc needed to compile ingest

### DIFF
--- a/contrib/ubuntu_installer/ubuntu_installer.sh
+++ b/contrib/ubuntu_installer/ubuntu_installer.sh
@@ -73,7 +73,9 @@ lightspeed_install() {
             curl \
             nginx \
             certbot \
-            python3-certbot-nginx
+            python3-certbot-nginx \
+            gcc \
+            libc6-dev
 
     ## Install latest nodejs and npm:
     curl -sL https://deb.nodesource.com/setup_15.x | bash -


### PR DESCRIPTION
Ingest has a dependency to the `libc`-crate which requires `gcc` and `libc6-dev` to compile.
This PR adds this requirement to the install script as those two packages are not installed by default in a fresh setup of Ubuntu.