### PR TITLE
Add ICE server configuration support

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,11 @@ WEBSOCKET_PORT=8080
 
 WEB_PORT=8888
 
+# A comma separated list of ICE / STUN servers. Availiable servers can be found from:
+#  - https://gist.github.com/sagivo/3a4b2f2c7ac6e1b5267c2f1f59ac6c6b
+#  - Searching for "public ice servers" in the search engine of your choice
+ICE_SERVERS=stun:stun.l.google.com:19302,stun:stun1.l.google.com:19302,stun:stun.stunprotocol.org:3478
+
 INGEST_PORT=8084
 #Optionally hardcode a stream key (it will be prefixed by "77-")
 #STREAM_KEY=

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ go build
 | `--ports`  | A valid UDP port range | `20000-20500` | This sets the UDP ports that WebRTC will use to connect with the client |
 | `--ws-port` | A valid port number | `8080` | This is the port on which the websocket will be hosted. If you change this value make sure that is reflected in the URL used by the react client |
 | `--rtp-port` | A valid port number | `65535` | This is the port on which the WebRTC service will listen for RTP packets. Ensure this is the same port that Lightspeed Ingest is negotiating with the client |
+| `--ice-servers` | A comma separated list of hosts | `none` | List of ICE / STUN servers used by WebRTC for setting up the network connection with the clients |
 
 #### Lightspeed React
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     restart: on-failure
     ports:
       - "${INGEST_PORT}:8084"
-  
+
   lightspeed-react:
     container_name: lightspeed-react
     image: projectlightspeed/react
@@ -36,7 +36,7 @@ services:
 #      context: ./webrtc
 #      dockerfile: Dockerfile
     env_file: '.env'
-    command: ["lightspeed-webrtc", "--addr=0.0.0.0", "--ip=${WEBSOCKET_HOST}", "--ports=20000-20100", "run"]
+    command: ["lightspeed-webrtc", "--addr=0.0.0.0", "--ip=${WEBSOCKET_HOST}", "--ports=20000-20100", "--ice-servers=${ICE_SERVERS}", "run"]
     restart: on-failure
     ports:
       - ${WEBSOCKET_PORT}:8080 # WebRTC


### PR DESCRIPTION
This fixes connection issues with the setup I have (Project-Lightspeed on a public server behinde a Nginx proxy with SSL).

I not a WebRTC expert, this is just the result of half a day of trial and error trying to get my setup working. I finally stumbled accross [this in the WebRTC examples](https://github.com/pion/webrtc/blob/master/examples/broadcast/main.go#L29-L35) and it fixed all my issues.